### PR TITLE
Set interpolation when exporting to pygfx

### DIFF
--- a/src/cmap/_colormap.py
+++ b/src/cmap/_colormap.py
@@ -703,8 +703,14 @@ class Colormap:
         """Return a vispy colormap."""
         return _external.to_vispy(self)
 
-    def to_pygfx(self, N: int = 256, *, as_view: bool | None = None) -> pygfx.Texture:
-        """Return a pygfx Texture."""
+    def to_pygfx(
+        self, N: int = 256, *, as_view: bool | None = None
+    ) -> pygfx.TextureMap:
+        """Return a pygfx TextureMap.
+
+        Note that it is recommended to use at least 256 colors for the LUT.
+        https://github.com/pygfx/pygfx/pull/1025#issuecomment-2706170445
+        """
         if as_view is not None:
             warnings.warn(
                 "as_view argument is deprecated and does nothing",

--- a/src/cmap/_external.py
+++ b/src/cmap/_external.py
@@ -62,7 +62,7 @@ def to_vispy(cm: Colormap) -> VispyColormap:
     return Colormap(colors=cm.color_stops.color_array, controls=cm.color_stops.stops)
 
 
-def to_pygfx(cm: Colormap, N: int = 256) -> pygfx.Texture:
+def to_pygfx(cm: Colormap, N: int = 256) -> pygfx.TextureMap:
     """Return a pygfx Texture."""
     import pygfx
 
@@ -70,7 +70,11 @@ def to_pygfx(cm: Colormap, N: int = 256) -> pygfx.Texture:
     # and if so, use that instead of .lut()
     # (get_view has a filter argument... but I don't know whether it will take
     # care of the stops)
-    return pygfx.Texture(cm.lut(N).astype(np.float32), dim=1)
+    pygfx_texture = pygfx.Texture(cm.lut(N).astype(np.float32), dim=1)
+
+    return pygfx.TextureMap(
+        texture=pygfx_texture, filter=cm.interpolation, wrap="clamp"
+    )
 
 
 def to_plotly(cm: Colormap) -> list[list[float | str]]:

--- a/tests/test_third_party.py
+++ b/tests/test_third_party.py
@@ -111,11 +111,17 @@ def test_pygfx(qapp: "QApplication") -> None:
     # camera.position.x = IMG.shape[1] / 2
     # camera.scale.y = -1
 
+    # check that the colormap interpolation is set
+    color_map = CMAP.to_pygfx()
+    assert color_map.mag_filter == CMAP.interpolation
+    assert color_map.min_filter == CMAP.interpolation
+    assert color_map.mipmap_filter == CMAP.interpolation
+
     scene = gfx.Scene()
     scene.add(
         gfx.Image(
             gfx.Geometry(grid=gfx.Texture(IMG, dim=2)),
-            gfx.ImageBasicMaterial(clim=(0, IMG.max()), map=CMAP.to_pygfx()),
+            gfx.ImageBasicMaterial(clim=(0, IMG.max()), map=color_map),
         )
     )
 


### PR DESCRIPTION
This PR updates the colormap export to PyGfx texture such that the interpolation function is set. Additionally, the function now returns a `gfx.TextureMap`, which is the current class used for colormaps in PyGfx.


Closes #86 