### PR TITLE
docs: fix 404 for names with dashes  in docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,20 +56,22 @@ jobs:
       - name: Run test
         run: pytest -v
 
+      - name: Skip remaining steps on Windows
+        if: runner.os == 'Windows'
+        shell: bash
+        run: exit 0
+
       - name: Install third-party dependencies
-        if: runner.os != 'Windows'
         run: |
           python -m pip install -e .[test_thirdparty] ${{ github.event_name == 'schedule' && '--pre' || ''  }}
-          python -m pip install PyQt6==6.5.3
+          python -m pip install PyQt6==6.8.1
 
       - name: Run test
-        if: runner.os != 'Windows'
         uses: aganders3/headless-gui@v2.2
         with:
           run: pytest -v --cov=cmap --cov-report=xml --cov-report=term-missing
 
       - name: Coverage
-        if: runner.os != 'Windows'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,22 +56,20 @@ jobs:
       - name: Run test
         run: pytest -v
 
-      - name: Skip remaining steps on Windows
-        if: runner.os == 'Windows'
-        shell: bash
-        run: exit 0
-
       - name: Install third-party dependencies
+        if: runner.os != 'Windows'
         run: |
           python -m pip install -e .[test_thirdparty] ${{ github.event_name == 'schedule' && '--pre' || ''  }}
           python -m pip install PyQt6==6.8.1
 
       - name: Run test
+        if: runner.os != 'Windows'
         uses: aganders3/headless-gui@v2.2
         with:
           run: pytest -v --cov=cmap --cov-report=xml --cov-report=term-missing
 
       - name: Coverage
+        if: runner.os != 'Windows'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,4 +34,4 @@ repos:
       - id: mypy
         files: "^src/"
         additional_dependencies:
-          - numpy>=2
+          - numpy>=2.2

--- a/docs/_gen_cmaps.py
+++ b/docs/_gen_cmaps.py
@@ -96,6 +96,8 @@ def build_catalog(catalog: "_catalog.Catalog") -> None:
         except KeyError as e:
             raise KeyError(f"Missing info for {name}: {e}") from e
 
+        # FIXME: not a great way to determine aliases...
+        # prone to false positives if normalization is not perfect/consistent
         if info.qualified_name.lower() != name.lower():
             # skip aliases
             continue

--- a/src/cmap/_catalog.py
+++ b/src/cmap/_catalog.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import warnings
 from collections.abc import Container, Iterable, Iterator, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -196,6 +197,17 @@ def _build_catalog(records: Iterable[FileDescriptorOrPath]) -> CatalogDict:
                         "should not have colon."
                     )
                 ctlg[f"{namespace}{NAMESPACE_DELIMITER}{alias}"] = {"alias": namespaced}
+
+    if dashed_names := {
+        k for k in ctlg if "-" in k and "alias" not in ctlg[k]
+    }:  # pragma: no cover
+        warnings.warn(
+            f"The following colormap names contain dashes in the record.json: "
+            f"{dashed_names}.\n\n"
+            "This is unsupported and will cause issues for docs. "
+            "Please use underscores instead.",
+            stacklevel=2,
+        )
 
     return ctlg
 

--- a/src/cmap/_colormap.py
+++ b/src/cmap/_colormap.py
@@ -1399,7 +1399,7 @@ def _mpl_segmentdata_to_stops(
         alpha = np.ones_like(all_positions)
 
     rgba = np.stack([*rgb, alpha], axis=1)
-    return [(a, tuple(b)) for a, b in zip(all_positions, rgba.tolist())]
+    return [(a, tuple(b)) for a, b in zip(all_positions, rgba.tolist())]  # type: ignore
 
 
 def _make_identifier(name: str) -> str:

--- a/src/cmap/data/tol/record.json
+++ b/src/cmap/data/tol/record.json
@@ -39,7 +39,7 @@
       "data": "cmap.data.tol:bright",
       "interpolation": false
     },
-    "bright-alt": {
+    "bright_alt": {
       "category": "qualitative",
       "data": "cmap.data.tol:bright_alt",
       "interpolation": false
@@ -49,12 +49,12 @@
       "data": "cmap.data.tol:dark",
       "interpolation": false
     },
-    "high-contrast": {
+    "high_contrast": {
       "category": "qualitative",
       "data": "cmap.data.tol:high_contrast",
       "interpolation": false
     },
-    "high-contrast-alt": {
+    "high_contrast_alt": {
       "category": "qualitative",
       "data": "cmap.data.tol:high_contrast_alt",
       "interpolation": false
@@ -72,17 +72,17 @@
       "data": "cmap.data.tol:light",
       "interpolation": false
     },
-    "light-alt": {
+    "light_alt": {
       "category": "qualitative",
       "data": "cmap.data.tol:light_alt",
       "interpolation": false
     },
-    "medium-contrast": {
+    "medium_contrast": {
       "category": "qualitative",
       "data": "cmap.data.tol:medium_contrast",
       "interpolation": false
     },
-    "medium-contrast-alt": {
+    "medium_contrast_alt": {
       "category": "qualitative",
       "data": "cmap.data.tol:medium_contrast_alt",
       "interpolation": false
@@ -92,7 +92,7 @@
       "data": "cmap.data.tol:muted",
       "interpolation": false
     },
-    "muted-alt": {
+    "muted_alt": {
       "category": "qualitative",
       "data": "cmap.data.tol:muted_alt",
       "interpolation": false
@@ -256,7 +256,7 @@
       "data": "cmap.data.tol:vibrant",
       "interpolation": false
     },
-    "vibrant-alt": {
+    "vibrant_alt": {
       "category": "qualitative",
       "data": "cmap.data.tol:vibrant_alt",
       "interpolation": false


### PR DESCRIPTION
fixes #98  (which was caused by a faulty check for whether a name was an alias during building of the docs).  The workaround is to prevent any keys with dashes in the record.json files.  This is somewhat hacky, but I added a warning for now which will fail tests if another dashed name is added in the future.   If we *really* need dashed keys in record.json, we can fix it later