### PR TITLE
Set mypy to only run on pre-push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,5 @@ repos:
         files: "^src/"
         additional_dependencies:
           - numpy>=2.2
+        stages:
+          - pre-push


### PR DESCRIPTION
Type checking is very slow (while we await our rust-based saviours ty, pyrefly, pylyzer...) which discourages modular one-job commits and small fixes. It would be great to have every commit fully type checked but the DX is not great.