### PR TITLE
fix: mark glasbey as qualitative

### DIFF
--- a/src/cmap/data/glasbey/record.json
+++ b/src/cmap/data/glasbey/record.json
@@ -4,8 +4,9 @@
   ],
   "colormaps": {
     "glasbey": {
-      "category": "miscellaneous",
-      "data": "cmap.data.glasbey.prebuilt:glasbey"
+      "category": "qualitative",
+      "data": "cmap.data.glasbey.prebuilt:glasbey",
+      "interpolation": false
     }
   },
   "license": "CC0",

--- a/tests/test_glasbey.py
+++ b/tests/test_glasbey.py
@@ -38,3 +38,12 @@ def test_glasbey_create_palette(
             grid_size=grid_size,
             cvd_severity=cvd_severity,
         )
+
+
+def test_glasbey_is_qualitative() -> None:
+    """Glasbey's palette is 256 maximally distinct categories, not a ramp."""
+    from cmap import Colormap
+
+    cm = Colormap("glasbey:glasbey")
+    assert cm.category == "qualitative"
+    assert cm.interpolation == "nearest"


### PR DESCRIPTION
`glasbey` is recorded as a continuous `miscellaneous` colormap, but it is a categorical palette: 256 maximally distinct colors for labelling categories, ordered so that any prefix stays distinguishable (Glasbey et al., [doi:10.1002/col.20327](https://doi.org/10.1002/col.20327) — "Colour displays for categorical images").

Two consequences today:

```python
>>> from cmap import Colormap
>>> cm = Colormap("glasbey")
>>> cm.category, cm.interpolation
('miscellaneous', 'linear')      # blends between unrelated categories
>>> len(cm.lut(1000))
1000                             # from a palette that defines 256
```

Evidence, using only colormaps this catalog labels — median distance between adjacent entries:

```python
import numpy as np
from cmap import Colormap

def step(name):
    cm = Colormap(name)
    lut = np.asarray(cm.lut(cm.num_colors), float)[:, :3]
    return float(np.median(np.linalg.norm(np.diff(lut, axis=0), axis=1)))
```

| | median adjacent step |
|---|---|
| `glasbey` | **0.698** |
| catalog's qualitative colormaps | 0.524 (range 0.163–1.077) |
| `matplotlib:viridis` | 0.006 |
| `cmocean:thermal` | 0.007 |

## Change

`src/cmap/data/glasbey/record.json`: `category` → `qualitative`, `interpolation` → `false`, matching how `tol`'s discrete palettes are recorded.

After: `category == "qualitative"`, `interpolation == "nearest"`, and `num_colors == 256` is respected.

One test added in `tests/test_glasbey.py`.