### PR TITLE
fix: assign the "over" color to napari's high_color, not nan_color

### DIFF
--- a/src/cmap/_external.py
+++ b/src/cmap/_external.py
@@ -112,7 +112,7 @@ def to_napari(cm: Colormap) -> NapariColormap:
         if "nan_color" in param_names and cm.bad_color is not None:
             kwargs["nan_color"] = cm.bad_color.rgba
         if "high_color" in param_names and cm.over_color is not None:
-            kwargs["nan_color"] = cm.over_color.rgba
+            kwargs["high_color"] = cm.over_color.rgba
         if "low_color" in param_names and cm.under_color is not None:
             kwargs["low_color"] = cm.under_color.rgba
     return Colormap(**kwargs)

--- a/tests/test_third_party.py
+++ b/tests/test_third_party.py
@@ -73,6 +73,19 @@ def test_napari(qapp: "QApplication") -> None:
     v.close()
 
 
+@pytest.mark.filterwarnings("ignore")
+def test_napari_extreme_colors() -> None:
+    # nan_color/low_color/high_color were added in napari 0.6.1
+    pytest.importorskip("napari", minversion="0.6.1")
+
+    bad = "yellow"
+    ncm = Colormap(["black", "white"], under=UNDER, over=OVER, bad=bad).to_napari()
+
+    np.testing.assert_allclose(ncm.low_color, Color(UNDER).rgba)
+    np.testing.assert_allclose(ncm.high_color, Color(OVER).rgba)
+    np.testing.assert_allclose(ncm.nan_color, Color(bad).rgba)
+
+
 @pytest.mark.skipif(
     sys.platform == "darwin" and sys.version_info >= (3, 13),
     reason="not yet working upstream",


### PR DESCRIPTION
`Colormap.to_napari()` checks for napari's `high_color` field but assigns the over color to `nan_color` (`src/cmap/_external.py:115`), introduced in #103.

Two effects:

- `high_color` is never set, so values above the range fall back to napari's default instead of the requested over color;
- the assignment runs after the `bad_color` branch, so an explicitly configured `bad` color is silently replaced by the over color.

One-line fix plus a regression test asserting that `low_color`, `high_color`, and `nan_color` each receive their own color. The test requires napari >= 0.6.1, where those three fields were added — below that the converter correctly skips them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)