### PR TITLE
fix: preserve interpolation through construction and with_extremes()

### DIFF
--- a/src/cmap/_colormap.py
+++ b/src/cmap/_colormap.py
@@ -459,6 +459,7 @@ class Colormap:
             self.color_stops,
             name=self.name,
             category=self.category,
+            interpolation=self.interpolation,
             bad=bad,
             under=under,
             over=over,

--- a/src/cmap/_colormap.py
+++ b/src/cmap/_colormap.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import warnings
 from collections.abc import Iterable, Sequence
+from copy import copy
 from functools import partial
 from numbers import Number
 from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Union, cast, overload
@@ -306,7 +307,9 @@ class Colormap:
             name = value if isinstance(value, str) else "custom colormap"
 
         self.interpolation = _norm_interp(interpolation)
-        stops._interpolation = self.interpolation
+        if stops._interpolation != self.interpolation:
+            # stops may be owned by the caller: don't write the mode into it
+            stops = stops._with_interpolation(self.interpolation)
         self.color_stops = stops
         self.name = name
         self.identifier = _make_identifier(identifier or name)
@@ -1174,6 +1177,16 @@ class ColorStops(Sequence[ColorStop]):
 
     def _is_reversed_lut_func(self, f: Callable) -> TypeGuard[partial]:
         return isinstance(f, partial) and f.func is self._reverser
+
+    def _with_interpolation(self, interpolation: Interpolation) -> ColorStops:
+        """Return a copy of self, with a different interpolation mode.
+
+        A shallow copy: rebuilding from `_lut_func` would call the user's callable
+        a second time, which is neither cheap nor guaranteed to be repeatable.
+        """
+        new = copy(self)
+        new._interpolation = interpolation
+        return new
 
     def reversed(self) -> ColorStops:
         """Return a new ColorStops object with reversed colors."""

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -108,6 +108,15 @@ def test_construction_does_not_change_source_interpolation() -> None:
     npt.assert_array_equal(stops.to_lut(4), before)
 
 
+def test_with_extremes_preserves_interpolation() -> None:
+    cmap = Colormap(["red", "blue"], interpolation="nearest")
+
+    new = cmap.with_extremes(bad="red")
+
+    assert new.interpolation == "nearest"
+    npt.assert_array_equal(new.lut(4), cmap.lut(4))
+
+
 def test_colormap_copy() -> None:
     """Test Colormap copy."""
     import pickle

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -99,6 +99,15 @@ def test_colorstops_reversed_does_not_mutate_source() -> None:
     npt.assert_array_equal(np.asarray(stops), before)
 
 
+def test_construction_does_not_change_source_interpolation() -> None:
+    stops = Colormap(["red", "blue"], interpolation="nearest").color_stops
+    before = stops.to_lut(4).copy()
+
+    Colormap(stops, interpolation="linear")
+
+    npt.assert_array_equal(stops.to_lut(4), before)
+
+
 def test_colormap_copy() -> None:
     """Test Colormap copy."""
     import pickle


### PR DESCRIPTION
Two ways a colormap's interpolation mode goes missing.

**The constructor writes into stops it does not own.** The last line of `Colormap.__init__` sets the requested mode on the `ColorStops` it was handed (`src/cmap/_colormap.py:309`), and that object usually belongs to the caller: `_parse_colorstops` returns a `ColorStops` argument unchanged (`:1509`), and the `isinstance(value, Colormap)` branch takes `value.color_stops` directly (`:300`).

```python
base = Colormap(["red", "blue"], interpolation="nearest")
Colormap(base, interpolation="linear")   # discard the result

base.interpolation          # "nearest"
base.lut(4)                 # a smooth ramp: it renders linear now
```

The source keeps reporting `"nearest"` while rendering `"linear"`, so the object contradicts itself and nothing raises.

**`with_extremes()` drops the mode.** It forwards `name` and `category` but not `interpolation`, and `_norm_interp(None)` is `"linear"`, so one call converts a discrete colormap to a continuous one. An ordered class scheme like `colorbrewer:Blues_9` starts blending between classes after `with_extremes(bad=...)`.

The fixes are a shallow copy carrying its own mode, made only when the mode actually differs, and one added argument in `with_extremes`.

Shallow rather than rebuilt from scratch: a `ColorStops` can be backed by a user `lut_func`, and reconstructing would call that callable a second time over 256 values. Callables are part of the public `ColormapLike` API with no purity requirement, so a second call is neither free nor necessarily harmless.

Related (but not addressed here): `with_extremes` also drops `identifier`. I'm unclear whether an omitted `bad`/`under`/`over` should clear the existing one or leave it. 