### PR TITLE
fix: byteswap non-native input instead of reinterpreting it

### DIFF
--- a/src/cmap/_colormap.py
+++ b/src/cmap/_colormap.py
@@ -415,8 +415,7 @@ class Colormap:
         xa = np.array(x, copy=True)
         if not xa.dtype.isnative:
             # Native byteorder is faster.
-            native: Literal[">", "<"] = ">" if xa.dtype.byteorder in ("<", "=") else "<"
-            xa = xa.view(xa.dtype.newbyteorder(native))
+            xa = xa.byteswap().view(xa.dtype.newbyteorder())
         if xa.dtype.kind == "f":
             xa *= N
             # xa == 1 (== N after multiplication) is not out of range.

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -144,6 +144,14 @@ def test_colormap_apply() -> None:
     assert cmap1(swapped).shape == (10, 10, 4)
 
 
+def test_non_native_byte_order_maps_the_same_colors() -> None:
+    cmap = Colormap(["red", "blue"], under="green", over="yellow", bad="black")
+    native = np.array([-0.5, 0.0, 0.5, 1.0, 1.5, np.nan])
+    non_native = native.astype(native.dtype.newbyteorder())
+
+    npt.assert_array_equal(cmap(non_native), cmap(native))
+
+
 def test_colormap_masked_array_with_unmasked_nan() -> None:
     cmap = Colormap("viridis", bad="red")
     mask = [True, False, False, False]


### PR DESCRIPTION
Data in non-native byte order maps to the wrong colors.

- On a little-endian host, a big-endian float array has its bytes relabelled rather than
  reordered, so `-0.5`, `1.5` and `NaN` all decode as tiny denormals.
- They land on the first ramp color, which makes `under`, `over` and `bad` unreachable for
  such input.

```python
import numpy as np
from cmap import Colormap, Color

cmap = Colormap(["red", "blue"], under="green", over="yellow", bad="black")
native = np.array([-0.5, 0.5, 1.5, np.nan])
non_native = native.astype(native.dtype.newbyteorder())

print([Color(c).hex for c in cmap(native)])
print([Color(c).hex for c in cmap(non_native)])
```

```
['#008000', '#7F0080', '#FFFF00', '#000000']   # under, ramp, over, bad
['#FF0000', '#FF0000', '#FF0000', '#FF0000']   # all the first ramp color
```

The numpy 2 migration in #60 replaced `xa.byteswap().newbyteorder()`, which numpy 2 removed,
with a plain `.view()` of the swapped dtype. `byteswap().view(dtype.newbyteorder())` is the
numpy 2 spelling of the original, and what matplotlib uses today.