### PR TITLE
fix: handle scalar input with bytes=True in Colormap.__call__

### DIFF
--- a/src/cmap/_colormap.py
+++ b/src/cmap/_colormap.py
@@ -442,7 +442,12 @@ class Colormap:
         xa[mask_bad] = N + 2
 
         rgba = lut.take(xa, axis=0, mode="clip")
-        return rgba if np.iterable(x) else Color(rgba)
+        if np.iterable(x):
+            return rgba
+        if bytes:
+            # Normalize uint8 RGBA back to [0,1] float for Color constructor
+            return Color(rgba / 255)
+        return Color(rgba)
 
     def with_extremes(
         self,


### PR DESCRIPTION
## Summary

Fixes `Colormap.__call__` raising `ValueError` when called with a scalar input and `bytes=True`.

### Problem

When `bytes=True`, the LUT is converted to `uint8` before indexing. For scalar input, the result is a 4-element `uint8` array (e.g. `[32, 144, 140, 255]`), which is then passed to `Color()`. But `Color()` (via `parse_rgba`) only accepts:
- integer arrays of length 3 (RGB)
- float arrays of length 3 or 4

A `uint8` array of length 4 doesn't match either condition, raising `ValueError: Invalid color array`.

```python
cmap(0.5, bytes=True)  # raises ValueError
```

### Fix

When `bytes=True` and the input is scalar, normalize the `uint8` RGBA values back to `[0, 1]` float range before constructing `Color()`. The quantization to 8-bit is preserved — `Color(rgba / 255)` gives `#20908C` vs `#21918C` in float mode, showing the `bytes=True` effect.

### Test results

```python
>>> cmap(0.5, bytes=True)
#20908C  # was ValueError before
>>> cmap(0.5)
#21918C  # unchanged
>>> cmap(np.array([0.5]), bytes=True)
[[ 32 144 140 255]]  # unchanged
```

Closes #153
